### PR TITLE
Fixed lingering problems related to query limits

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="com.ionicframework.myearthapp496614" android-versionCode="500022" version="5.0.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.ionicframework.myearthapp496614" android-versionCode="500030" version="5.0.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>MyEarth</name>
   <description>
         Developed by John Meurer and Victor Tavares

--- a/www/js/controllers/timelineController.js
+++ b/www/js/controllers/timelineController.js
@@ -60,7 +60,11 @@ paradropCtrl.controller('timelineCtrl',
 
         var query = new Parse.Query('Activity');
         console.log('parse request: get activity list');
-        
+
+        // Override the implicit limit of 100.  If there are more than 1000
+        // activities for users to choose from, we will need to use pagination.
+        query.limit(1000);
+
         query.find({
             
             success: function(activities) {


### PR DESCRIPTION
The main issue addressed here is fetching more that 1,000 completed activities for displaying the impact graph and totals in the app.  I introduced a recursiveQuery function that will work for at least 10,000 entries.  I also increased the limit from the default (100) to 1,000 for fetching the activity choice list to prevent that from becoming an issue as well.